### PR TITLE
Updates to Virusshare analyzer

### DIFF
--- a/analyzers/Virusshare/getHashes.sh
+++ b/analyzers/Virusshare/getHashes.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# This script downloads all available Virusshare.com hash files using curl and wget. It can be called as: ./getHashes.sh PATH
+
+
+display_usage() { 
+    echo "getHashes v0.1" 
+    echo "  Fetch all Virusshare.com hashes" 
+    echo -e "\n  Usage: $0 <path> \n"
+} 
+
+if [  $# -ne 1 ]; then 
+    display_usage
+    exit 1
+fi
+
+if [ ! -d $1 ]; then
+    display_usage
+    echo -e "    Error: Directory not found: '$1'\n\n    :'(\n\n"
+    exit 1
+
+fi
+
+cd $1
+for u in `curl https://virusshare.com/hashes.4n6|grep hashes/|cut -d\" -f2`
+do
+    echo $u
+    wget https://virusshare.com/$u
+done | tee -a ../$0.log
+cd ..

--- a/analyzers/Virusshare/virusshare.py
+++ b/analyzers/Virusshare/virusshare.py
@@ -67,7 +67,7 @@ class VirusshareAnalyzer(Analyzer):
                     # Skipping comments
                     if line[0] == '#':
                         continue
-                    if line.strip('\n') == searchhash:
+                    if searchhash.lower() in line:
                         self.report({'isonvs': True,
                                      'md5': searchhash})
         self.report({'isonvs': False,

--- a/analyzers/Virusshare/virusshare.py
+++ b/analyzers/Virusshare/virusshare.py
@@ -28,7 +28,7 @@ class VirusshareAnalyzer(Analyzer):
         value = "\"Unknown\""
 
         if raw["isonvs"]:
-            if raw["isonvs"] == "Unknown":
+            if raw["isonvs"] == "unknown":
                 value = "\"Not MD5\""
                 level = "suspicious"
             else:
@@ -45,7 +45,7 @@ class VirusshareAnalyzer(Analyzer):
         if self.data_type == 'hash':
             searchhash = self.getData()
             if len(searchhash) != 32:
-                self.report({'isonvs': 'Unknown',
+                self.report({'isonvs': 'unknown',
                              'hash': searchhash})
         elif self.data_type == 'file':
             filepath = self.getParam('file')

--- a/analyzers/Virusshare/virusshare.py
+++ b/analyzers/Virusshare/virusshare.py
@@ -45,7 +45,7 @@ class VirusshareAnalyzer(Analyzer):
         if self.data_type == 'hash':
             searchhash = self.getData()
             if len(searchhash) != 32:
-                self.report({'isonvs': 'unknown',
+                self.report({'isonvs': 'Unknown',
                              'hash': searchhash})
         elif self.data_type == 'file':
             filepath = self.getParam('file')


### PR DESCRIPTION
I've added case insensitivity to the hash comparison within the analyzer. This is important because Virusshare stores all lowercase hashes, but if you compare an uppercase hash, it will always returns as not within the Virusshare dataset which can be dangerously incorrect.

I have benchmarked the comparison and found that the removal of the strip function actually improved the overall speed of the test when a line contains a single hash. Moving to the 'in' operator also allows for support of the UPX hash map file that has been created.

---

I've also added a simple bash script to fetch the hashes since I had issues with python version that is available. Bash is simpler and more or less always works as expected whereas python could apparently have issue that are harder to fix than (in this case) simply writing a bash based tool.