### PR TITLE
Fixes bug in MISP client

### DIFF
--- a/analyzers/MISP/mispclient.py
+++ b/analyzers/MISP/mispclient.py
@@ -27,8 +27,14 @@ class MISPClient:
         if type(url) is list:
             for idx, server in enumerate(url):
                 verify = True
-                if os.path.isfile(ssl[idx]):
-                    verify = ssl[idx]
+                if isinstance(ssl, list):
+                    if os.path.isfile(ssl[idx]):
+                        verify = ssl[idx]
+                elif isinstance(ssl, str):
+                    if os.path.isfile(ssl):
+                        verify = ssl
+                elif isinstance(ssl, bool):
+                    verify = ssl
                 self.misp_connections.append(pymisp.PyMISP(url=server,
                                                            key=key[idx],
                                                            ssl=verify))


### PR DESCRIPTION
This fixes a bug in MISP client, mentioned in #87, which throws a type error if config parameter certpath is empty.

Unfortunately, I currently don't have a proper testing evironment for this - can someone (@nadouani, @jeromeleonard) review/test this? Thank you.