### PR TITLE
MISP Analyzer: forgot to add same procedure if using just one MISP-Server

### DIFF
--- a/analyzers/MISP/mispclient.py
+++ b/analyzers/MISP/mispclient.py
@@ -40,7 +40,10 @@ class MISPClient:
                                                            ssl=verify))
         else:
             verify = True
-            if os.path.isfile(ssl):
+            if isinstance(ssl, str):
+                if os.path.isfile(ssl):
+                    verify = ssl
+            elif isinstance(ssl, bool):
                 verify = ssl
             self.misp_connections.append(pymisp.PyMISP(url=url,
                                                        key=key,


### PR DESCRIPTION
This should fix #90, totally overlooked that. 