### PR TITLE
feat(ldapquery): add support multiple search fields

### DIFF
--- a/analyzers/LdapQuery/LdapQuery.json
+++ b/analyzers/LdapQuery/LdapQuery.json
@@ -48,7 +48,7 @@
         "name": "uid_search_field",
         "description": "Specify here the field to use when searching by username. Eg: uid or sAMAccountName",
         "type": "string",
-        "multi": false,
+        "multi": true,
         "required": true
     },
     {


### PR DESCRIPTION
This commit adds the possibility of defining multiple UID search fields which will result in a LDAP query checking for the given data in all those fields. This greatly increases the flexiblity of using this analyzer for checking multiple different input data.

E.g. given the following real life example. Organization defines users with different identifiable user references such as ([username] userx, [username] userx@iam.foo.bar, [email] userid@email.foo.bar, [email] idxxxxx@foo.bar). Those user references are all different fields within LDAP. Also alerts, such as in TheHive, generates a variarety of those datatypes as observables.  With the previous version of LDAPquery it was not possible to check all possible fields resulting in manually changing all the observables to follow a specific user reference

With this version it is possible use the LDAPQuery analyzer for all those use cases by simply adding more relevant UID Search fields.