### PR TITLE
[greynoise] Updates analyzer to support GreyNoise v3 API

### DIFF
--- a/analyzers/GreyNoise/GreyNoise.json
+++ b/analyzers/GreyNoise/GreyNoise.json
@@ -1,7 +1,7 @@
 {
   "name": "GreyNoise",
-  "version": "3.1",
-  "author": "Nclose",
+  "version": "3.2",
+  "author": "GreyNoise",
   "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
   "license": "APLv2",
   "description": "Determine whether an IP has known scanning activity using GreyNoise.",
@@ -14,14 +14,7 @@
       "description": "API key for GreyNoise",
       "type": "string",
       "multi": false,
-      "required": false
-    },
-    {
-      "name": "api_type",
-      "description": "API Type to Match Key, either 'enterprise' or 'community'",
-      "type": "string",
-      "multi": false,
-      "required": false
+      "required": true
     }
   ],
   "config": {

--- a/analyzers/GreyNoise/README.md
+++ b/analyzers/GreyNoise/README.md
@@ -8,7 +8,6 @@ The analyzer comes in a single flavour, but supports both the GreyNoise Paid and
 GreyNoise additional information categorization for provided ip.
 
 #### Requirements
-You need a valid GreyNoise API integration subscription or Community account to use the analyzer.
+You need a valid GreyNoise API integration subscription or Free account with a business email address to use the analyzer.
 
 - Provide your API key as values for the `key` parameter.
-- Provide your API key type as "enterprise" (the default) or "community" for the `api_type` parameter

--- a/analyzers/GreyNoise/requirements.txt
+++ b/analyzers/GreyNoise/requirements.txt
@@ -1,2 +1,2 @@
 cortexutils
-greynoise>=0.8.0
+greynoise==3.0.1


### PR DESCRIPTION
Changes:
- Pins greynoise SDK to version 3.0.1 to avoid future issues with breaking changes
- Updates api logic to support new SDK implementation
- Merges community and free lookups into a single call, removed api_type param as it is no longer needed
- Adds logic to support different response use cases available in the API response

Addresses issue noted in:
https://github.com/TheHive-Project/Cortex-Analyzers/issues/1368