### PR TITLE
Update onyphe_analyzer.py

### DIFF
--- a/analyzers/Onyphe/onyphe_analyzer.py
+++ b/analyzers/Onyphe/onyphe_analyzer.py
@@ -528,9 +528,9 @@ class OnypheAnalyzer(Analyzer):
                     # from: https://search.onyphe.io/docs/onyphe-query-language
                     # asn should be in the form "AS<digits>"
                     if data.isdigit():
-                        data = 'AS{asn}'.format(asn=data)                        
-                    if data.startswith("AS-"):
-                        data = "AS"+data[3:]
+                        data = 'AS{asn}'.format(asn=data)
+                    if data.startswith('AS-'):
+                        data = 'AS{asn}'.format(asn=data[3:])
                     ctifilter += 'ip.asn:{asn} '.format(asn=data)
                 elif self.data_type == "other":
                     try:


### PR DESCRIPTION
The autonomous-system datatypes is ambiguous and used differently in the Analyzers (that is onyphe and IVRE). Specifically onyphe wants the AS in the form of "AS"+<digit>. IVRE on the other end uses just digits.

I think that the correct form is the latter and we should check this in the analyzer it self.