### PR TITLE
Update MSEntraID analyzers

### DIFF
--- a/analyzers/MSEntraID/MSEntraID.py
+++ b/analyzers/MSEntraID/MSEntraID.py
@@ -560,8 +560,8 @@ class MSEntraID(Analyzer):
             self.error({"message": "Unidentified service"})
 
     def operations(self, raw):
-        if not raw:
-            return [self.build_operation("AddTagToArtifact", tag="MSEntraID:GUID:Not Found")]
+        if raw.get('message') and 'No user matches' in str(raw.get('message', '')):
+            return [self.build_operation("AddTagToArtifact", tag="MSEntraID:GUID:NotFound")]
 
     def summary(self, raw):
         taxonomies = []


### PR DESCRIPTION
- better error message report
- added tag to artifacts when no GUID is found
- remove GUID filter since this does not work


Regarding the GUID filter, in the Intune Managed Device API it seems that the `userId` oData option is not recognized:
```
,  "Message": "Unsupported parameter found in query ... "
```

In my research I see that this API suffers of many other problems:
- https://learn.microsoft.com/en-us/answers/questions/1179430/manageddevice

