### PR TITLE
Add DFIR Platform analyzers

### DIFF
--- a/analyzers/DFIRPlatform_ExposureScan/DFIRPlatform_ExposureScan.json
+++ b/analyzers/DFIRPlatform_ExposureScan/DFIRPlatform_ExposureScan.json
@@ -1,0 +1,31 @@
+{
+    "name": "DFIRPlatform_ExposureScan",
+    "version": "1.0",
+    "author": "DFIR Lab",
+    "url": "https://github.com/dfir-lab/dfir-cortex-analyzers",
+    "license": "MIT",
+    "description": "Scan a domain's attack surface using the DFIR Platform API. Aggregates data from 11 providers including Shodan, Criminal IP, SSL Labs, crt.sh, and more to identify exposed services, misconfigurations, and vulnerabilities.",
+    "dataTypeList": ["domain"],
+    "command": "DFIRPlatform_ExposureScan/DFIRPlatform_ExposureScan.py",
+    "baseConfig": "DFIRPlatform",
+    "registration_required": true,
+    "subscription_required": false,
+    "free_subscription": true,
+    "configurationItems": [
+        {
+            "name": "api_key",
+            "description": "API key for the DFIR Platform. Obtain one at https://platform.dfir-lab.ch",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "base_url",
+            "description": "Base URL for the DFIR Platform API",
+            "type": "string",
+            "multi": false,
+            "required": false,
+            "defaultValue": "https://api.dfir-lab.ch/v1"
+        }
+    ]
+}

--- a/analyzers/DFIRPlatform_ExposureScan/DFIRPlatform_ExposureScan.py
+++ b/analyzers/DFIRPlatform_ExposureScan/DFIRPlatform_ExposureScan.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""DFIR Platform Exposure Scan Analyzer for Cortex."""
+
+import requests
+from cortexutils.analyzer import Analyzer
+
+
+class DFIRPlatformExposureScan(Analyzer):
+    """Scan a domain's attack surface via the DFIR Platform API."""
+
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.api_key = self.get_param(
+            "config.api_key", None, "Missing DFIR Platform API key"
+        )
+        self.base_url = self.get_param(
+            "config.base_url", "https://api.dfir-lab.ch/v1"
+        ).rstrip("/")
+
+    def run(self):
+        if self.data_type != "domain":
+            self.error("This analyzer only accepts domain observables.")
+            return
+
+        domain = self.get_data()
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/exposure/scan",
+                headers={
+                    "X-API-Key": self.api_key,
+                    "Content-Type": "application/json",
+                },
+                json={"domain": domain},
+                timeout=180,
+            )
+        except requests.exceptions.RequestException as e:
+            self.error(f"Connection error: {str(e)}")
+            return
+
+        if response.status_code == 401:
+            self.error("Invalid API key. Check your DFIR Platform API key.")
+            return
+        elif response.status_code == 402:
+            self.error(
+                "Insufficient credits. Top up at https://platform.dfir-lab.ch"
+            )
+            return
+        elif response.status_code == 429:
+            self.error("Rate limit exceeded. Please wait before retrying.")
+            return
+        elif response.status_code != 200:
+            self.error(
+                f"API error (HTTP {response.status_code}): {response.text}"
+            )
+            return
+
+        try:
+            self.report(response.json())
+        except ValueError:
+            self.error(f"Invalid JSON in API response: {response.text[:200]}")
+
+    def summary(self, raw):
+        taxonomies = []
+        namespace = "DFIRPlatform"
+        predicate = "Exposure"
+
+        open_ports = raw.get("open_ports", [])
+        port_count = len(open_ports) if isinstance(open_ports, list) else 0
+
+        vulnerabilities = raw.get("vulnerabilities", [])
+        vuln_count = (
+            len(vulnerabilities) if isinstance(vulnerabilities, list) else 0
+        )
+
+        if vuln_count > 0:
+            level = "malicious"
+        elif port_count > 10:
+            level = "suspicious"
+        else:
+            level = "info"
+
+        taxonomies.append(
+            self.build_taxonomy(
+                level, namespace, "OpenPorts", str(port_count)
+            )
+        )
+
+        if vuln_count > 0:
+            taxonomies.append(
+                self.build_taxonomy(
+                    "malicious", namespace, "Vulnerabilities", str(vuln_count)
+                )
+            )
+
+        ssl_grade = raw.get("ssl_grade")
+        if ssl_grade:
+            if ssl_grade in ("A+", "A"):
+                ssl_level = "safe"
+            elif ssl_grade in ("B", "C"):
+                ssl_level = "suspicious"
+            else:
+                ssl_level = "malicious"
+            taxonomies.append(
+                self.build_taxonomy(
+                    ssl_level, namespace, "SSLGrade", ssl_grade
+                )
+            )
+
+        providers_count = raw.get("providers_queried", 0)
+        if providers_count > 0:
+            taxonomies.append(
+                self.build_taxonomy(
+                    "info", namespace, "Providers", str(providers_count)
+                )
+            )
+
+        return {"taxonomies": taxonomies}
+
+
+if __name__ == "__main__":
+    DFIRPlatformExposureScan().run()

--- a/analyzers/DFIRPlatform_ExposureScan/requirements.txt
+++ b/analyzers/DFIRPlatform_ExposureScan/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+requests

--- a/analyzers/DFIRPlatform_IOCEnrichment/DFIRPlatform_IOCEnrichment.json
+++ b/analyzers/DFIRPlatform_IOCEnrichment/DFIRPlatform_IOCEnrichment.json
@@ -1,0 +1,31 @@
+{
+    "name": "DFIRPlatform_IOCEnrichment",
+    "version": "1.0",
+    "author": "DFIR Lab",
+    "url": "https://github.com/dfir-lab/dfir-cortex-analyzers",
+    "license": "MIT",
+    "description": "Enrich indicators of compromise (IPs, domains, hashes, URLs) using the DFIR Platform API. Aggregates intelligence from 14+ sources including VirusTotal, AbuseIPDB, Shodan, and more.",
+    "dataTypeList": ["ip", "domain", "hash", "url"],
+    "command": "DFIRPlatform_IOCEnrichment/DFIRPlatform_IOCEnrichment.py",
+    "baseConfig": "DFIRPlatform",
+    "registration_required": true,
+    "subscription_required": false,
+    "free_subscription": true,
+    "configurationItems": [
+        {
+            "name": "api_key",
+            "description": "API key for the DFIR Platform. Obtain one at https://platform.dfir-lab.ch",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "base_url",
+            "description": "Base URL for the DFIR Platform API",
+            "type": "string",
+            "multi": false,
+            "required": false,
+            "defaultValue": "https://api.dfir-lab.ch/v1"
+        }
+    ]
+}

--- a/analyzers/DFIRPlatform_IOCEnrichment/DFIRPlatform_IOCEnrichment.py
+++ b/analyzers/DFIRPlatform_IOCEnrichment/DFIRPlatform_IOCEnrichment.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""DFIR Platform IOC Enrichment Analyzer for Cortex."""
+
+import requests
+from cortexutils.analyzer import Analyzer
+
+
+class DFIRPlatformIOCEnrichment(Analyzer):
+    """Enrich IOCs (IPs, domains, hashes, URLs) via the DFIR Platform API."""
+
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.api_key = self.get_param(
+            "config.api_key", None, "Missing DFIR Platform API key"
+        )
+        self.base_url = self.get_param(
+            "config.base_url", "https://api.dfir-lab.ch/v1"
+        ).rstrip("/")
+
+    def run(self):
+        data_type = self.data_type
+        if data_type not in ("ip", "domain", "hash", "url"):
+            self.error(f"Unsupported data type: {data_type}")
+            return
+
+        observable = self.get_data()
+
+        try:
+            response = requests.post(
+                f"{self.base_url}/ioc/enrich",
+                headers={
+                    "X-API-Key": self.api_key,
+                    "Content-Type": "application/json",
+                },
+                json={"type": data_type, "value": observable},
+                timeout=120,
+            )
+        except requests.exceptions.RequestException as e:
+            self.error(f"Connection error: {str(e)}")
+            return
+
+        if response.status_code == 401:
+            self.error("Invalid API key. Check your DFIR Platform API key.")
+            return
+        elif response.status_code == 402:
+            self.error(
+                "Insufficient credits. Top up at https://platform.dfir-lab.ch"
+            )
+            return
+        elif response.status_code == 429:
+            self.error("Rate limit exceeded. Please wait before retrying.")
+            return
+        elif response.status_code != 200:
+            self.error(
+                f"API error (HTTP {response.status_code}): {response.text}"
+            )
+            return
+
+        try:
+            self.report(response.json())
+        except ValueError:
+            self.error(f"Invalid JSON in API response: {response.text[:200]}")
+
+    def summary(self, raw):
+        taxonomies = []
+        level = "info"
+        namespace = "DFIRPlatform"
+        predicate = "IOCEnrichment"
+
+        malicious_count = raw.get("malicious_count", 0)
+        total_sources = raw.get("total_sources", 0)
+
+        if malicious_count > 0:
+            level = "malicious"
+            value = f"{malicious_count}/{total_sources} malicious"
+        elif raw.get("suspicious", False):
+            level = "suspicious"
+            value = f"suspicious ({total_sources} sources)"
+        else:
+            level = "safe"
+            value = f"clean ({total_sources} sources)"
+
+        taxonomies.append(
+            self.build_taxonomy(level, namespace, predicate, value)
+        )
+
+        risk_score = raw.get("risk_score")
+        if risk_score is not None:
+            if risk_score >= 80:
+                score_level = "malicious"
+            elif risk_score >= 40:
+                score_level = "suspicious"
+            else:
+                score_level = "safe"
+            taxonomies.append(
+                self.build_taxonomy(
+                    score_level, namespace, "RiskScore", f"{risk_score}/100"
+                )
+            )
+
+        return {"taxonomies": taxonomies}
+
+
+if __name__ == "__main__":
+    DFIRPlatformIOCEnrichment().run()

--- a/analyzers/DFIRPlatform_IOCEnrichment/requirements.txt
+++ b/analyzers/DFIRPlatform_IOCEnrichment/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+requests

--- a/analyzers/DFIRPlatform_PhishingAnalysis/DFIRPlatform_PhishingAnalysis.json
+++ b/analyzers/DFIRPlatform_PhishingAnalysis/DFIRPlatform_PhishingAnalysis.json
@@ -1,0 +1,31 @@
+{
+    "name": "DFIRPlatform_PhishingAnalysis",
+    "version": "1.0",
+    "author": "DFIR Lab",
+    "url": "https://github.com/dfir-lab/dfir-cortex-analyzers",
+    "license": "MIT",
+    "description": "Analyze phishing emails (EML files) using the DFIR Platform API. Runs 26+ analysis modules including SPF/DKIM/DMARC validation, header anomaly detection, URL reputation checks, attachment scanning, and more.",
+    "dataTypeList": ["file"],
+    "command": "DFIRPlatform_PhishingAnalysis/DFIRPlatform_PhishingAnalysis.py",
+    "baseConfig": "DFIRPlatform",
+    "registration_required": true,
+    "subscription_required": false,
+    "free_subscription": true,
+    "configurationItems": [
+        {
+            "name": "api_key",
+            "description": "API key for the DFIR Platform. Obtain one at https://platform.dfir-lab.ch",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "base_url",
+            "description": "Base URL for the DFIR Platform API",
+            "type": "string",
+            "multi": false,
+            "required": false,
+            "defaultValue": "https://api.dfir-lab.ch/v1"
+        }
+    ]
+}

--- a/analyzers/DFIRPlatform_PhishingAnalysis/DFIRPlatform_PhishingAnalysis.py
+++ b/analyzers/DFIRPlatform_PhishingAnalysis/DFIRPlatform_PhishingAnalysis.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""DFIR Platform Phishing Analysis Analyzer for Cortex."""
+
+import requests
+from cortexutils.analyzer import Analyzer
+
+
+class DFIRPlatformPhishingAnalysis(Analyzer):
+    """Analyze phishing emails via the DFIR Platform API."""
+
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.api_key = self.get_param(
+            "config.api_key", None, "Missing DFIR Platform API key"
+        )
+        self.base_url = self.get_param(
+            "config.base_url", "https://api.dfir-lab.ch/v1"
+        ).rstrip("/")
+
+    def run(self):
+        if self.data_type != "file":
+            self.error("This analyzer only accepts file (EML) inputs.")
+            return
+
+        filepath = self.get_param("file", None, "No file provided")
+        filename = self.get_param("filename", "email.eml")
+
+        if not filename.lower().endswith(".eml"):
+            self.error(
+                "This analyzer expects EML files. "
+                "Please submit a .eml email file."
+            )
+            return
+
+        try:
+            with open(filepath, "rb") as f:
+                response = requests.post(
+                    f"{self.base_url}/phishing/analyze",
+                    headers={"X-API-Key": self.api_key},
+                    files={"file": (filename, f, "message/rfc822")},
+                    timeout=180,
+                )
+        except FileNotFoundError:
+            self.error(f"File not found: {filepath}")
+            return
+        except requests.exceptions.RequestException as e:
+            self.error(f"Connection error: {str(e)}")
+            return
+
+        if response.status_code == 401:
+            self.error("Invalid API key. Check your DFIR Platform API key.")
+            return
+        elif response.status_code == 402:
+            self.error(
+                "Insufficient credits. Top up at https://platform.dfir-lab.ch"
+            )
+            return
+        elif response.status_code == 429:
+            self.error("Rate limit exceeded. Please wait before retrying.")
+            return
+        elif response.status_code != 200:
+            self.error(
+                f"API error (HTTP {response.status_code}): {response.text}"
+            )
+            return
+
+        try:
+            self.report(response.json())
+        except ValueError:
+            self.error(f"Invalid JSON in API response: {response.text[:200]}")
+
+    def summary(self, raw):
+        taxonomies = []
+        namespace = "DFIRPlatform"
+        predicate = "Phishing"
+
+        verdict = raw.get("verdict", "unknown").lower()
+        confidence = raw.get("confidence", 0)
+
+        if verdict == "phishing":
+            level = "malicious"
+            value = f"phishing ({confidence}% confidence)"
+        elif verdict == "suspicious":
+            level = "suspicious"
+            value = f"suspicious ({confidence}% confidence)"
+        elif verdict == "legitimate":
+            level = "safe"
+            value = "legitimate"
+        else:
+            level = "info"
+            value = "unknown"
+
+        taxonomies.append(
+            self.build_taxonomy(level, namespace, predicate, value)
+        )
+
+        modules_triggered = raw.get("modules_triggered", 0)
+        total_modules = raw.get("total_modules", 0)
+        if total_modules > 0:
+            taxonomies.append(
+                self.build_taxonomy(
+                    "info",
+                    namespace,
+                    "Modules",
+                    f"{modules_triggered}/{total_modules}",
+                )
+            )
+
+        auth = raw.get("authentication", {})
+        spf = auth.get("spf", "unknown")
+        dkim = auth.get("dkim", "unknown")
+        dmarc = auth.get("dmarc", "unknown")
+
+        auth_fails = sum(
+            1 for r in [spf, dkim, dmarc] if r.lower() == "fail"
+        )
+        if auth_fails > 0:
+            taxonomies.append(
+                self.build_taxonomy(
+                    "suspicious",
+                    namespace,
+                    "AuthFails",
+                    f"{auth_fails}/3",
+                )
+            )
+
+        return {"taxonomies": taxonomies}
+
+
+if __name__ == "__main__":
+    DFIRPlatformPhishingAnalysis().run()

--- a/analyzers/DFIRPlatform_PhishingAnalysis/requirements.txt
+++ b/analyzers/DFIRPlatform_PhishingAnalysis/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+requests


### PR DESCRIPTION
## Summary

Adds three new analyzers for the [DFIR Platform](https://platform.dfir-lab.ch) API:

- **DFIRPlatform_IOCEnrichment** — Enriches IPs, domains, hashes, and URLs via 14+ intelligence sources
- **DFIRPlatform_PhishingAnalysis** — Analyzes EML files with 26+ modules (SPF/DKIM/DMARC validation, header analysis, URL reputation, QR code decoding, AI-powered verdicts)
- **DFIRPlatform_ExposureScan** — Scans domain attack surface by aggregating 11 providers (Shodan, Criminal IP, Netlas, SSL Labs, crt.sh, SecurityTrails, etc.)

## Configuration

All three analyzers share the `DFIRPlatform` base config namespace with two settings:
- `api_key` (required) — obtained from [platform.dfir-lab.ch](https://platform.dfir-lab.ch)
- `base_url` (optional) — defaults to `https://api.dfir-lab.ch/v1`

## Pricing

DFIR Platform uses a credit-based model. A free tier is available (100 credits/month, no credit card required). Each API call costs 1-60 credits depending on the operation.

## Testing

All analyzers have been tested locally against the live API. Error handling covers authentication failures (401), credit exhaustion (402), rate limiting (429), and connection errors.

## Disclosure

I am the creator of DFIR Platform. This is a self-submission.