### PR TITLE
GeoIP_Custom

### DIFF
--- a/analyzers/GeoIP_Custom/GeoIP_Custom.json
+++ b/analyzers/GeoIP_Custom/GeoIP_Custom.json
@@ -1,0 +1,25 @@
+{
+  "name": "GeoIP_Custom",
+  "version": "1.0",
+  "author": "Ommmdevv19",
+  "url": "https://github.com/Ommmdevv19/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Custom GeoIP Analyzer with country-based IOC flagging",
+  "dataTypeList": [
+    "ip"
+  ],
+  "baseConfig": "GeoIP_Custom",
+  "command": "GeoIP_Custom/GeoIP_Custom.py",
+  "configurationItems": [
+    {
+      "name": "flagged_countries",
+      "description": "Comma-separated list of country codes to flag as IOC (e.g. RU,CN,KP)",
+      "type": "string",
+      "multi": false,
+      "required": false
+    }
+  ],
+  "registration_required": false,
+  "subscription_required": false,
+  "service_homepage": "https://ip-api.com"
+}

--- a/analyzers/GeoIP_Custom/GeoIP_Custom.py
+++ b/analyzers/GeoIP_Custom/GeoIP_Custom.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+import requests
+from cortexutils.analyzer import Analyzer
+
+
+class GeoIPCustom(Analyzer):
+
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.flagged_countries = self.get_param("config.flagged_countries", "") or ""
+
+    def summary(self, raw):
+        taxonomies = []
+        level = "info"
+        namespace = "GeoIP_Custom"
+
+        country = raw.get("country", "Unknown")
+        country_code = raw.get("countryCode", "Unknown")
+
+        # Add basic country taxonomy
+        taxonomies.append(self.build_taxonomy(level, namespace, "Country", country))
+
+        # Add IOC taxonomy if the country matches the flagged list
+        if raw.get("flagged", False):
+            taxonomies.append(
+                self.build_taxonomy(
+                    "suspicious", namespace, "IOC", f"{country} ({country_code})"
+                )
+            )
+
+        return {"taxonomies": taxonomies}
+
+    def run(self):
+        Analyzer.run(self)
+        if self.data_type == "ip":
+            data = self.get_data()
+            url = f"http://ip-api.com/json/{data}"
+
+            try:
+                with requests.Session() as session:
+                    response = session.get(url, timeout=10)
+                    response.raise_for_status()
+                    result = response.json()
+
+                    if result.get("status") == "success":
+                        country_code = result.get("countryCode", "").strip().upper()
+
+                        # Parse flagged countries (comma-separated, case-insensitive)
+                        flagged_list = [
+                            c.strip().upper()
+                            for c in self.flagged_countries.split(",")
+                            if c.strip()
+                        ]
+
+                        # Check if the returned country code is flagged
+                        result["flagged"] = country_code in flagged_list
+
+                        self.report(result)
+                    else:
+                        self.error(result.get("message", "Failed to lookup IP info"))
+            except requests.RequestException as e:
+                self.error(f"HTTP request failed: {e}")
+            except Exception as e:
+                self.unexpectedError(e)
+        else:
+            self.notSupported()
+
+
+if __name__ == "__main__":
+    GeoIPCustom().run()

--- a/analyzers/GeoIP_Custom/requirements.txt
+++ b/analyzers/GeoIP_Custom/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+requests

--- a/thehive-templates/GeoIP_Custom_1_0/long.html
+++ b/thehive-templates/GeoIP_Custom_1_0/long.html
@@ -1,0 +1,82 @@
+<!-- Success -->
+<div class="panel panel-info" ng-if="success && content.status !== 'fail'">
+    <div class="panel-heading">
+        Geolocation of <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <table class="table table-hover">
+            <tr>
+                <th>Continent</th>
+                <td>{{content.continent}} ({{content.continentCode}})</td>
+            </tr>
+            <tr>
+                <th>Country</th>
+                <td>
+                    {{content.country}} ({{content.countryCode}})
+                    <span class="label label-warning" ng-if="content.flagged">Flagged Country</span>
+                </td>
+            </tr>
+            <tr>
+                <th>Region</th>
+                <td>{{content.regionName}} ({{content.region}})</td>
+            </tr>
+            <tr>
+                <th>City</th>
+                <td>{{content.city}}</td>
+            </tr>
+            <tr>
+                <th>ZIP</th>
+                <td>{{content.zip}}</td>
+            </tr>
+            <tr>
+                <th>Latitude</th>
+                <td>{{content.lat}}</td>
+            </tr>
+            <tr>
+                <th>Longitude</th>
+                <td>{{content.lon}}</td>
+            </tr>
+            <tr>
+                <th>ISP</th>
+                <td>{{content.isp}}</td>
+            </tr>
+            <tr>
+                <th>Organization</th>
+                <td>{{content.org}}</td>
+            </tr>
+            <tr>
+                <th>AS</th>
+                <td>{{content.as}}</td>
+            </tr>
+            <tr>
+                <th>Query</th>
+                <td>{{content.query}}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+
+<!-- Success but fail -->
+<div class="panel panel-danger" ng-if="success && content.status == 'fail'">
+    <div class="panel-heading">
+        Error querying <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <p><strong>Status:</strong> {{content.status}}</p>
+        <p><strong>Message:</strong> {{content.message}}</p>
+        <p><strong>Query:</strong> {{content.query}}</p>
+    </div>
+</div>
+
+<!-- General error -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{ (artifact.data || artifact.attachment.name) | fang }}</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i> GeoIP Custom:</dt>
+            <dd class="wrap">{{ content.errorMessage }}</dd>
+        </dl>
+    </div>
+</div>

--- a/thehive-templates/GeoIP_Custom_1_0/short.html
+++ b/thehive-templates/GeoIP_Custom_1_0/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}="{{t.value}}"
+</span>


### PR DESCRIPTION
## Description
This Pull Request introduces a new custom analyzer, **GeoIP_Custom**, which enables country-based flagging of IP addresses as Indicators of Compromise (IOC).

### Features
- **IP Geolocation**: Performs geolocation queries using the IP-API service (`ip-api.com`).
- **Country-based IOC Flagging**: Allows administrators to specify a comma-separated list of country codes (e.g., `RU,CN,KP`) in the analyzer configuration. If the analyzed IP falls under any of the configured countries, it is automatically flagged as suspicious/IOC.
- **Report Templates Included**: Bundles both `short.html` (summary report showing taxonomy levels) and `long.html` (detailed geolocation report table showing ISP, Organization, Region, City, AS, and query status).

### Structure
- **Analyzer Code**: `analyzers/GeoIP_Custom/GeoIP_Custom.py`
- **Analyzer Manifest**: `analyzers/GeoIP_Custom/GeoIP_Custom.json`
- **Report Templates**: `thehive-templates/GeoIP_Custom_1_0/`