### PR TITLE
Fix Elasticsearch analyzer TypeError when optional configurations are…

### DIFF
--- a/analyzers/Elasticsearch/elk.py
+++ b/analyzers/Elasticsearch/elk.py
@@ -5,6 +5,7 @@ from cortexutils.analyzer import Analyzer
 import dateutil.parser
 from datetime import datetime
 from packaging.version import Version
+from itertools import zip_longest
 
 # utils
 import operator
@@ -156,7 +157,28 @@ class ElasticsearchAnalyzer(Analyzer):
             # client-side numeric timeout (works across 8.x/9.x)
             client_timeout = 30  # seconds
 
-            for endpoint,key,user,password in zip(self.endpoints,self.keys,self.users,self.passwords):
+            # Normalize parameter lists to handle optional omitted config items
+            if self.endpoints is None:
+                self.endpoints = []
+            elif isinstance(self.endpoints, str):
+                self.endpoints = [self.endpoints]
+
+            if self.keys is None:
+                self.keys = []
+            elif not isinstance(self.keys, list):
+                self.keys = [self.keys]
+
+            if self.users is None:
+                self.users = []
+            elif not isinstance(self.users, list):
+                self.users = [self.users]
+
+            if self.passwords is None:
+                self.passwords = []
+            elif not isinstance(self.passwords, list):
+                self.passwords = [self.passwords]
+
+            for endpoint,key,user,password in zip_longest(self.endpoints,self.keys,self.users,self.passwords, fillvalue=None):
                 hosts = [endpoint] if isinstance(endpoint, str) else endpoint
                 es_dict = dict(
                             hosts=hosts,


### PR DESCRIPTION
This PR fixes issue #1291, where the Elasticsearch analyzer raises a TypeError when optional configuration parameters (keys, users, or passwords) are omitted.

The issue occurred because Python's built-in zip() function was called on self.endpoints, self.keys, self.users, and self.passwords without checking if the optional fields were configured. If any of these fields were left empty (resolving to None), the zip() call raised a TypeError.

Key Changes:
Imported zip_longest from the standard itertools library.
Normalized Parameter Lists: Handled cases where optional configurations are None or string values, converting them to lists.
Graceful Iteration: Replaced zip with zip_longest(..., fillvalue=None) to loop through configured endpoints and their credentials, even if their list lengths are mismatched or unconfigured.
Testing Done
Checked syntax compilation of elk.py (no errors).
Validated normalization logic under multiple configurations (default unconfigured optionals, string endpoint with None optionals, mismatched credential list lengths).
Verified the analyzer's execution path using mock endpoints and mock credentials without raising a TypeError.