### PR TITLE
UnshortenLink - Security Hardening

### DIFF
--- a/analyzers/UnshortenLink/unshortenlink.py
+++ b/analyzers/UnshortenLink/unshortenlink.py
@@ -1,9 +1,46 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
+import ipaddress
+import socket
 import requests
-import re
+from urllib.parse import urlparse
 from cortexutils.analyzer import Analyzer
+
+_CGNAT_NET = ipaddress.ip_network("100.64.0.0/10")  # not flagged by is_private
+
+
+def _ip_blocked(ip):
+    if ip.version == 6 and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped  # ::ffff:127.0.0.1 -> 127.0.0.1
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+        or ip in _CGNAT_NET
+    )
+
+
+def _is_ssrf_target(url):
+    host = urlparse(url).hostname
+    if not host:
+        return True
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return True
+    for _, _, _, _, sockaddr in infos:
+        addr = sockaddr[0].split("%")[0]  # strip IPv6 scope id
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            return True
+        if _ip_blocked(ip):
+            return True
+    return False
 
 
 class UnshortenlinkAnalyzer(Analyzer):
@@ -36,29 +73,8 @@ class UnshortenlinkAnalyzer(Analyzer):
         Analyzer.run(self)
 
         url = self.get_data()
-        if len(re.findall(
-                r"^(http:\/\/)?(https:\/\/)?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?(\/)?$",
-                url)) > 0 \
-                or len(re.findall(r"^(http:\/\/)?(https:\/\/)?.+:[0-9]{1,5}$", url)) \
-                or len(re.findall(r'^(http:\/\/\[)?(https:\/\/\[)('
-                                  '([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|'
-                                  '([0-9a-fA-F]{1,4}:){1,7}:|'
-                                  '([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|'
-                                  '([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|'
-                                  '([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|'
-                                  '([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|'
-                                  '([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|'
-                                  '[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|'
-                                  ':((:[0-9a-fA-F]{1,4}){1,7}|:)|'
-                                  'fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|'
-                                  '::(ffff(:0{1,4}){0,1}:){0,1}' + \
-                                  '((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}'
-                                  '(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|'
-                                  '([0-9a-fA-F]{1,4}:){1,4}:'
-                                  '((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}'
-                                  '(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])'
-                                  ')(\])?(:[0-9]{1,5})?$', url)):
-            self.error("Searching for Ports and IPs not allowed.")
+        if _is_ssrf_target(url):
+            self.error("URL resolves to a private or reserved address not allowed.")
 
         if self.proxies:
             proxies = self.proxies


### PR DESCRIPTION
SSRF host-filter hardening, follow-up to CVE-2019-7652.

Replace the regex URL filter with hostname resolution + IP-range checks so hosts resolving to internal addresses are rejected.

Discovered by **Ali Ganiyev** (independent researcher).