### PR TITLE
Add HashScanner_NSRL analyzer (NIST NSRL known-file lookup)

### DIFF
--- a/analyzers/HashScanner/HashScanner_NSRL.json
+++ b/analyzers/HashScanner/HashScanner_NSRL.json
@@ -1,0 +1,46 @@
+{
+  "name": "HashScanner_NSRL",
+  "author": "HashScanner",
+  "license": "MIT",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0",
+  "description": "Look up a file hash (MD5/SHA-1/SHA-256) in the NIST NSRL via HashScanner — instantly tell whether it is a known (cataloged) file so you can filter the known and focus on the unknown.",
+  "dataTypeList": ["hash"],
+  "baseConfig": "HashScanner",
+  "config": {
+    "check_tlp": true,
+    "max_tlp": 2,
+    "check_pap": true,
+    "max_pap": 2
+  },
+  "command": "HashScanner/hashscanner_analyzer.py",
+  "configurationItems": [
+    {
+      "name": "api_key",
+      "description": "HashScanner API key (hs_..._sk_...). Get a free key at https://www.hashscanner.com/register",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "api_url",
+      "description": "HashScanner API base URL",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": "https://api.hashscanner.com/v1"
+    },
+    {
+      "name": "timeout",
+      "description": "Request timeout in seconds",
+      "type": "number",
+      "multi": false,
+      "required": false,
+      "defaultValue": 30
+    }
+  ],
+  "registration_required": true,
+  "subscription_required": true,
+  "free_subscription": true,
+  "service_homepage": "https://www.hashscanner.com"
+}

--- a/analyzers/HashScanner/LICENSE
+++ b/analyzers/HashScanner/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Linsbury Ltd (HashScanner)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/analyzers/HashScanner/README.md
+++ b/analyzers/HashScanner/README.md
@@ -1,0 +1,26 @@
+# HashScanner_NSRL
+
+Cortex analyzer that looks up a **hash** observable in the **NIST NSRL** via the
+[HashScanner](https://www.hashscanner.com) API. It tells you whether the file is
+**known** (cataloged in NSRL) so you can filter the known out of a case and focus on
+the unknown.
+
+> A match means the file is *known* — **not** that it is safe, clean, or malicious.
+> NIST does not label files good or bad.
+
+- **Data type:** `hash` (MD5 / SHA-1 / SHA-256)
+- **Requires:** a HashScanner API key — free at <https://www.hashscanner.com/register>
+
+## Configuration
+
+| Item | Required | Default | Description |
+|------|----------|---------|-------------|
+| `api_key` | yes | — | Your key, `hs_..._sk_...` |
+| `api_url` | no | `https://api.hashscanner.com/v1` | API base URL |
+| `timeout` | no | `30` | Request timeout (seconds) |
+
+## Output
+
+`short` report — a single taxonomy badge: `HashScanner:NSRL=Known` or `=Unknown`.
+
+`long` report — the file metadata when known (name, size, product, OS, source).

--- a/analyzers/HashScanner/hashscanner_analyzer.py
+++ b/analyzers/HashScanner/hashscanner_analyzer.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""HashScanner Cortex analyzer — look up a file hash in the NIST NSRL.
+
+A match means the file is *known* (cataloged in NSRL), which lets analysts filter out
+files they already recognise — it is NOT a safe, clean, or malicious verdict.
+
+Get a free API key at https://www.hashscanner.com/register
+"""
+
+import requests
+from cortexutils.analyzer import Analyzer
+
+API_DEFAULT = "https://api.hashscanner.com/v1"
+
+
+class HashScannerAnalyzer(Analyzer):
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.api_key = self.get_param(
+            "config.api_key", None, "HashScanner API key is missing"
+        )
+        self.api_url = self.get_param("config.api_url", API_DEFAULT).rstrip("/")
+        self.timeout = self.get_param("config.timeout", 30)
+
+    def summary(self, raw):
+        # "known" / "unknown" are stated as info — NSRL membership is not a verdict.
+        value = "Known" if raw.get("found") else "Unknown"
+        return {"taxonomies": [self.build_taxonomy("info", "HashScanner", "NSRL", value)]}
+
+    def run(self):
+        if self.data_type != "hash":
+            self.error("HashScanner only supports the 'hash' data type")
+        observable = self.get_data() or ""
+        h = observable.strip().lower()
+        if not h:
+            self.error("No hash supplied")
+
+        headers = {
+            "Authorization": "Bearer {}".format(self.api_key),
+            "User-Agent": "hashscanner-cortex/1.0",
+        }
+        try:
+            resp = requests.get(
+                "{}/hash/{}".format(self.api_url, h),
+                headers=headers,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            self.error("HashScanner request failed: {}".format(exc))
+
+        if resp.status_code == 200:
+            self.report(resp.json())
+            return
+        if resp.status_code == 404:
+            # Not cataloged in NSRL — a valid "unknown" result, not an error.
+            self.report({"found": False, "hash": h})
+            return
+        if resp.status_code == 401:
+            self.error("Invalid HashScanner API key")
+        if resp.status_code == 403:
+            self.error("HashScanner subscription inactive — renew or upgrade")
+        if resp.status_code == 429:
+            self.error("HashScanner rate limit or monthly quota exceeded")
+        self.error("HashScanner error {}: {}".format(resp.status_code, resp.text))
+
+
+if __name__ == "__main__":
+    HashScannerAnalyzer().run()

--- a/analyzers/HashScanner/requirements.txt
+++ b/analyzers/HashScanner/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+requests>=2.25

--- a/thehive-templates/HashScanner_NSRL_1_0/long.html
+++ b/thehive-templates/HashScanner_NSRL_1_0/long.html
@@ -1,0 +1,35 @@
+<div class="panel" ng-class="content.found ? 'panel-info' : 'panel-default'">
+  <div class="panel-heading">
+    <strong>HashScanner</strong> &mdash; NIST NSRL
+  </div>
+  <div class="panel-body">
+
+    <div ng-if="content.found">
+      <dl class="dl-horizontal">
+        <dt>Status</dt><dd><span class="label label-info">Known (cataloged in NSRL)</span></dd>
+        <dt>Hash</dt><dd>{{content.hash}}</dd>
+        <dt>Type</dt><dd>{{content.type}}</dd>
+        <dt ng-if="content.data.file.file_name">File name</dt>
+        <dd ng-if="content.data.file.file_name">{{content.data.file.file_name}}</dd>
+        <dt ng-if="content.data.file.file_size">File size</dt>
+        <dd ng-if="content.data.file.file_size">{{content.data.file.file_size}} bytes</dd>
+        <dt ng-if="content.data.package.name">Product</dt>
+        <dd ng-if="content.data.package.name">{{content.data.package.name}}</dd>
+        <dt ng-if="content.data.operating_system.name">OS</dt>
+        <dd ng-if="content.data.operating_system.name">{{content.data.operating_system.name}}</dd>
+        <dt ng-if="content.data.manufacturer">Manufacturer</dt>
+        <dd ng-if="content.data.manufacturer">{{content.data.manufacturer}}</dd>
+        <dt ng-if="content.data.reputation.source">Source</dt>
+        <dd ng-if="content.data.reputation.source">{{content.data.reputation.source}}</dd>
+      </dl>
+      <p><em>&ldquo;Known&rdquo; means the file is cataloged in NSRL &mdash; not that it is
+      safe, clean, or malicious.</em></p>
+    </div>
+
+    <div ng-if="!content.found">
+      <p><strong>Not found in NSRL.</strong> This hash is not cataloged &mdash; it may
+      warrant a closer look.</p>
+    </div>
+
+  </div>
+</div>

--- a/thehive-templates/HashScanner_NSRL_1_0/short.html
+++ b/thehive-templates/HashScanner_NSRL_1_0/short.html
@@ -1,0 +1,5 @@
+<span class="label"
+      ng-repeat="t in content.taxonomies"
+      ng-class="{'info':'label-info','safe':'label-success','suspicious':'label-warning','malicious':'label-danger'}[t.level]">
+  {{t.namespace}}:{{t.predicate}} = {{t.value}}
+</span>


### PR DESCRIPTION
Looks up a hash observable against the NIST NSRL via the HashScanner API and reports whether the file is known (cataloged). Taxonomy HashScanner:NSRL=Known/Unknown.

Closes #1462